### PR TITLE
修复 session 无效的问题

### DIFF
--- a/config/session.js
+++ b/config/session.js
@@ -12,6 +12,14 @@
  * http://sailsjs.org/#!/documentation/reference/sails.config/sails.config.session.html
  */
 
+const parseDomain = require('parse-domain');
+const globals = require('./globals').globals;
+
+const url = parseDomain(globals.api);
+const cookie = {
+  domain: url ? ('.' + url.domain + '.' + url.tld) : null,
+}
+
 module.exports.session = {
 
   /***************************************************************************
@@ -30,6 +38,8 @@ module.exports.session = {
   user: process.env.POSTGRES_USER || 'postgres',
   password: process.env.POSTGRES_PWD,
   port: 5432,
+
+  cookie,
 
   /***************************************************************************
   *                                                                          *

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "nodemailer": "^4.4.2",
     "nodemailer-express-handlebars": "^2.0.0",
     "oauth": "^0.9.15",
+    "parse-domain": "^2.0.0",
     "pg": "^7.4.1",
     "query-string": "^5.0.1",
     "rc": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3192,6 +3192,10 @@ pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
 
+parse-domain@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-domain/-/parse-domain-2.0.0.tgz#e9f42f697c30f7c2051dc5c55ff4d8a80da7943c"
+
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"


### PR DESCRIPTION
Sails 设置 session cookie 的 domain 为 /，亦即 api.langchao.org。当我们请求 langchao.org 时，请求中并不会包含其子域名的 session。

之前 session 都是在同一域名下（localhost）进行测试，并未发现问题。