### PR TITLE
返回事件信息时根据请求包含对应新闻

### DIFF
--- a/api/controllers/EventController.js
+++ b/api/controllers/EventController.js
@@ -9,7 +9,9 @@ const EventController = {
 
   getEvent: async (req, res) => {
     const name = req.param('eventName');
-    const event = await EventService.findEvent(name);
+    const event = await EventService.findEvent(name, {
+      includes: req.query,
+    });
 
     if (event) {
       res.status(200).json(event);


### PR DESCRIPTION
在请求事件的链接中，包含事件下进展和新闻的对应 ID，即可确保返回的事件数据包含所需新闻。

请求格式 `GET /event/:id?stack={Stack ID}&news={News ID}`

若事件下并无对应进展或进展下无对应新闻，则正常返回数据。